### PR TITLE
Add cancellable async generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Java Parser Demo Backend
 
 This repository provides a simple backend service for generating JUnit tests
-from Java source code. The service exposes a small Flask API that extracts
-methods using `javaparser` and generates tests via an LLM.
+from Java source code. The service exposes a small **FastAPI** application that
+extracts methods using `javaparser` and generates tests via an LLM.
 
 ## Requirements
 
@@ -25,7 +25,7 @@ API for generating tests.
 ## Running the server
 
 ```bash
-python app.py
+uvicorn app:app --reload
 ```
 
 Send a POST request to `/generate` with JSON containing either `file_path` or
@@ -39,3 +39,10 @@ curl -X POST http://localhost:8000/generate -H 'Content-Type: application/json' 
 ```
 
 The response contains the generated JUnit test.
+
+## Asynchronous generation
+
+You can also start test generation as a background task which can be
+cancelled. Use `/start-generate` to begin generation. The response will
+include a `task_id` which can be checked via `/status/<task_id>` or
+cancelled via `/cancel/<task_id>`.

--- a/app.py
+++ b/app.py
@@ -1,100 +1,123 @@
-from flask import Flask, request, jsonify, send_file
-from extract_method import extract_method
-from junit_test_generator import generate_junit_test
-import os
+from fastapi import FastAPI, Request, HTTPException
+from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.middleware.cors import CORSMiddleware
 import io
+import os
 import zipfile
 
-# Add CORS support to allow requests from UI
-from flask_cors import CORS
+from extract_method import extract_method
+from junit_test_generator import generate_junit_test
+from task_manager import start_generation, cancel_task, get_status
 
-app = Flask(__name__)
-CORS(app) # Enable CORS for all routes
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
-@app.route('/generate', methods=['POST'])
-def generate():
-    # Check if request has JSON data or form data
-    if request.is_json:
-        data = request.get_json()
-        print("Received JSON data:", data)
-    else:
-        data = request.form.to_dict()
-        print("Received form data:", data)
 
+def _get_request_data(request: Request):
+    if request.headers.get("content-type", "").startswith("application/json"):
+        return request.json()
+    return request.form()
+
+
+@app.post("/generate")
+async def generate(request: Request):
+    data = await _get_request_data(request)
     if not data:
-        return jsonify({'error': 'No data provided'}), 400
+        raise HTTPException(status_code=400, detail="No data provided")
 
     java_file = None
-    # handle raw code
-    if data.get('code'):
-        java_file = 'TempInput.java'
-        print("Writing code to file:", java_file)
-        with open(java_file, 'w') as f:
-            f.write(data['code'])
-    elif data.get('file_path'):
-        java_file = data['file_path']
-        print("Using file path:", java_file)
+    if data.get("code"):
+        java_file = "TempInput.java"
+        with open(java_file, "w") as f:
+            f.write(data["code"])
+    elif data.get("file_path"):
+        java_file = data["file_path"]
     else:
-        return jsonify({'error': 'Provide code or file_path'}), 400
+        raise HTTPException(status_code=400, detail="Provide code or file_path")
 
     method_code = extract_method(java_file)
-    print("Extracted method code:", method_code)
     if method_code is None:
-        return jsonify({'error': 'Failed to extract method'}), 500
+        raise HTTPException(status_code=500, detail="Failed to extract method")
 
     junit_test = generate_junit_test(method_code)
-    print("Generated JUnit test:", junit_test)
-    return jsonify({'junit_test': junit_test})
+    return JSONResponse({"junit_test": junit_test})
 
 
-@app.route('/generate-tests', methods=['POST'])
-def generate_tests():
-    """Generate tests for multiple Java source files."""
-    # Check if request has JSON data or form data
-    if request.is_json:
-        data = request.get_json()
-        print("Received JSON data:", data)
+@app.post("/start-generate")
+async def start_generate(request: Request):
+    data = await _get_request_data(request)
+    if not data:
+        raise HTTPException(status_code=400, detail="No data provided")
+
+    java_file = None
+    if data.get("code"):
+        java_file = "TempInput.java"
+        with open(java_file, "w") as f:
+            f.write(data["code"])
+    elif data.get("file_path"):
+        java_file = data["file_path"]
     else:
-        data = request.form.to_dict()
-        print("Received form data:", data)
-        # Convert form data files to expected format
-        if 'files' in data:
-            data['files'] = eval(data['files'])
-            print("Converted files data:", data['files'])
+        raise HTTPException(status_code=400, detail="Provide code or file_path")
 
-    if not data or 'files' not in data:
-        return jsonify({'error': 'No files provided'}), 400
+    method_code = extract_method(java_file)
+    if method_code is None:
+        raise HTTPException(status_code=500, detail="Failed to extract method")
 
-    files = data['files']
+    task_id = start_generation(method_code)
+    return JSONResponse({"task_id": task_id})
+
+
+@app.get("/status/{task_id}")
+async def status(task_id: str):
+    return JSONResponse(get_status(task_id))
+
+
+@app.post("/cancel/{task_id}")
+async def cancel(task_id: str):
+    if cancel_task(task_id):
+        return JSONResponse({"status": "cancelling"})
+    raise HTTPException(status_code=404, detail="unknown task")
+
+
+@app.post("/generate-tests")
+async def generate_tests(request: Request):
+    data = await _get_request_data(request)
+    if not data or "files" not in data:
+        raise HTTPException(status_code=400, detail="No files provided")
+
+    files = data["files"]
     if not isinstance(files, list):
-        return jsonify({'error': 'files must be a list'}), 400
+        raise HTTPException(status_code=400, detail="files must be a list")
 
-    # Map of output filename to test content
     test_files = {}
     for file in files:
-        name = file.get('name')
-        content = file.get('content')
-        print(f"Processing file: {name}")
+        name = file.get("name")
+        content = file.get("content")
         if not name or content is None:
             continue
         junit = generate_junit_test(content)
         test_name = name.rsplit('.', 1)[0] + 'Test.java'
         test_files[test_name] = junit
-        print(f"Generated test for {name} -> {test_name}")
 
     mem_zip = io.BytesIO()
     with zipfile.ZipFile(mem_zip, 'w') as zf:
         for fname, code in test_files.items():
             zf.writestr(fname, code)
-            print(f"Added {fname} to zip file")
     mem_zip.seek(0)
-    return send_file(
+    return StreamingResponse(
         mem_zip,
-        mimetype='application/zip',
-        as_attachment=True,
-        download_name='junit-tests.zip'
+        media_type="application/zip",
+        headers={"Content-Disposition": "attachment; filename=junit-tests.zip"},
     )
 
-if __name__ == '__main__':
-    port = int(os.getenv('PORT', 8000))
-    app.run(host='0.0.0.0', port=port)
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.getenv("PORT", 8000))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-flask
+fastapi
+uvicorn
 openai
 langgraph
 langchain

--- a/task_manager.py
+++ b/task_manager.py
@@ -1,0 +1,52 @@
+import threading
+import uuid
+from typing import Dict, Any
+
+from junit_test_generator import generate_junit_test
+
+
+class TaskInfo:
+    def __init__(self, thread: threading.Thread, cancel_event: threading.Event, result: Dict[str, Any]):
+        self.thread = thread
+        self.cancel_event = cancel_event
+        self.result = result
+
+
+tasks: Dict[str, TaskInfo] = {}
+
+
+def start_generation(method_code: str) -> str:
+    task_id = str(uuid.uuid4())
+    cancel_event = threading.Event()
+    result: Dict[str, Any] = {"status": "running", "junit_test": None}
+
+    def run():
+        if cancel_event.is_set():
+            result["status"] = "cancelled"
+            return
+        junit = generate_junit_test(method_code, cancel_event=cancel_event)
+        if cancel_event.is_set():
+            result["status"] = "cancelled"
+            return
+        result["junit_test"] = junit
+        result["status"] = "completed"
+
+    thread = threading.Thread(target=run, daemon=True)
+    tasks[task_id] = TaskInfo(thread, cancel_event, result)
+    thread.start()
+    return task_id
+
+
+def cancel_task(task_id: str) -> bool:
+    info = tasks.get(task_id)
+    if not info:
+        return False
+    info.cancel_event.set()
+    return True
+
+
+def get_status(task_id: str) -> Dict[str, Any]:
+    info = tasks.get(task_id)
+    if not info:
+        return {"status": "unknown"}
+    return info.result


### PR DESCRIPTION
## Summary
- switch server to FastAPI with async endpoints
- update documentation for FastAPI usage
- requirements now include fastapi and uvicorn

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866553b595c83229db685c3b24ab320